### PR TITLE
fix: infinite loop when setting up DNS hijacking

### DIFF
--- a/root/usr/share/xray/gen_config.lua
+++ b/root/usr/share/xray/gen_config.lua
@@ -534,6 +534,11 @@ end
 local function dns_server_outbound()
     return {
         protocol = "dns",
+        streamSettings = {
+            sockopt = {
+                mark = tonumber(proxy.mark)
+            }
+        },
         tag = "dns_server_outbound"
     }
 end


### PR DESCRIPTION
将 53 端口数据转发到 xray 中进行处理，会触发死循环。本 PR 解决了此问题。


```json
{
    "log": {
        "access": "/var/log/v2ray-access.log",
        "error": "/var/log/v2ray-error.log",
        "loglevel": "warning",
        "dnsLog": false
    },
    "outbounds": [
        {
            "protocol": "blackhole",
            "tag": "block"
        }
    ],
    "routing": {
        "rules": [
            {
                "type": "field",
                "port": 53,
                "inboundTag": [
                    "socks_inbound",
                    "http_inbound",
                    "tproxy_tcp_inbound",
                    "tproxy_udp_inbound"
                ],
                "outboundTag": "dns_server_outbound"
            },
            {
                "type": "field",
                "inboundTag": [
                    "socks_inbound",
                    "http_inbound",
                    "tproxy_tcp_inbound",
                    "dns_conf_inbound"
                ],
                "outboundTag": "tcp_outbound"
            },
            {
                "type": "field",
                "inboundTag": [
                    "tproxy_udp_inbound"
                ],
                "outboundTag": "udp_outbound"
            },
            {
                "type": "field",
                "inboundTag": [
                    "dns_server_inbound"
                ],
                "outboundTag": "dns_server_outbound"
            },
            {
                "type": "field",
                "inboundTag": [
                    "api"
                ],
                "outboundTag": "api"
            }
        ],
        "domainStrategy": "IPIfNonMatch"
    }
}
```