### PR TITLE
fix: force restart dnsmasq on interface change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-xray
-PKG_VERSION:=1.23.2
+PKG_VERSION:=1.23.3
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MPLv2

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Focus on making the most of Xray (HTTP/HTTPS/Socks/TProxy inbounds, multiple pro
 * 2022-10-06 `[OpenWrt 22.03 or above only]` feat: use goto instead of jump in nftables rules
 * 2022-10-29 `[OpenWrt 22.03 or above only]` feat: rewrite gen_config in ucode
 * 2022-11-01 feat: support xtls-rprx-vision
+* 2022-12-13 fix: force restart dnsmasq on interface change
 
 ## Changelog 2021
 

--- a/root/etc/hotplug.d/iface/01-transparent-proxy-ipset.fw3
+++ b/root/etc/hotplug.d/iface/01-transparent-proxy-ipset.fw3
@@ -7,6 +7,7 @@ if [ -n "$DEFAULT_GATEWAY" ] ; then
 		flush tp_spec_def_gw
 		add tp_spec_def_gw $DEFAULT_GATEWAY
 	EOF
+    service dnsmasq restart
 else
     logger -st transparent-proxy-ipset[$$] -p6 "default gateway not available, please wait for interface ready"
 fi

--- a/root/etc/hotplug.d/iface/01-transparent-proxy-ipset.fw4
+++ b/root/etc/hotplug.d/iface/01-transparent-proxy-ipset.fw4
@@ -7,6 +7,7 @@ if [ -n "$DEFAULT_GATEWAY" ] ; then
 		flush set inet fw4 tp_spec_def_gw
 		add element inet fw4 tp_spec_def_gw { $DEFAULT_GATEWAY }
 	EOF
+    service dnsmasq restart
 else
     logger -st transparent-proxy-ipset[$$] -p6 "default gateway not available, please wait for interface ready"
 fi


### PR DESCRIPTION
There seems to be a problem related to dnsmasq which prevents it from correctly loading configuration file while being reloaded. Force restart dnsmasq to avoid that.