### PR TITLE
bugfix for reverse proxy

### DIFF
--- a/fw4/root/usr/share/xray/gen_config.uc
+++ b/fw4/root/usr/share/xray/gen_config.uc
@@ -874,7 +874,7 @@ function bridge_outbounds() {
         const v = config[key];
         i = i + 1;
         const bridge_server = config[v["upstream"]];
-        for (i in server_outbound(bridge_server, sprintf("bridge_upstream_outbound_%d", i))) {
+        for (f in server_outbound(bridge_server, sprintf("bridge_upstream_outbound_%d", i))) {
             splice(result, 0, 0, f);
         }
         splice(result, 0, 0, {


### PR DESCRIPTION


反向代理的配置生成有个小bug，for 循环这里的局部变量错了，导致生成出来的配置文件 outbounds 中有个 null，原本应该是 `bridge_upstream_outbound_#`