### PR TITLE
重定向局域网 DNS 查询流量 / Redirect subnets dns queries

### DIFF
--- a/core/root/usr/share/xray/default_gateway.uc
+++ b/core/root/usr/share/xray/default_gateway.uc
@@ -111,7 +111,7 @@ const dump = network_dump();
 const dg = get_default_gateway(dump);
 const pd = get_prefix_delegate(dump);
 const lans = get_lan_addresses(dump);
-const log = join(", ", [...dg, ...pd]);
+const log = join(", ", [...dg, ...pd, ...lans.l4s, ...lans.l6s]);
 if (log == "") {
     print("default gateway not available, please wait for interface ready");
 } else {

--- a/core/root/usr/share/xray/default_gateway.uc
+++ b/core/root/usr/share/xray/default_gateway.uc
@@ -41,6 +41,25 @@ function get_prefix_delegate(dump) {
     return keys(pds);
 }
 
+function get_lan_addresses(dump) {
+    let l4s = {};
+    let l6s = {};
+    for (let i in dump["interface"] || []) {
+        if (i["l3_device"] == "br-lan") {
+            for (let j in i["ipv4-address"] || []) {
+                l4s[j["address"]] = true;
+            }
+            for (let k in i["ipv6-prefix-assignment"] || []) {
+                let la = k["local-address"];
+                if (la != null) {
+                    l6s[la["address"]] = true;
+                }
+            }
+        }
+    }
+    return { l4s: keys(l4s), l6s: keys(l6s) };
+}
+
 function gen_tp_spec_dv4_dg(dg) {
     if (stat("/usr/share/xray/ignore_tp_spec_def_gw")) {
         return "";
@@ -58,10 +77,26 @@ function gen_tp_spec_dv6_dg(pd) {
     return "";
 }
 
-function update_nft(dg, pd) {
+function gen_tp_spec_lv4_dr(l4s) {
+    if (length(l4s) > 0) {
+        return `flush set inet fw4 tp_spec_lv4_dr\nadd element inet fw4 tp_spec_lv4_dr { ${join(", ", l4s)} }\n`;
+    }
+    return "";
+}
+
+function gen_tp_spec_lv6_dr(l6s) {
+    if (length(l6s) > 0) {
+        return `flush set inet fw4 tp_spec_lv6_dr\nadd element inet fw4 tp_spec_lv6_dr { ${join(", ", l6s)} }\n`;
+    }
+    return "";
+}
+
+function update_nft(dg, pd, lans) {
     const process = popen("nft -f -", "w");
     process.write(gen_tp_spec_dv4_dg(dg));
     process.write(gen_tp_spec_dv6_dg(pd));
+    process.write(gen_tp_spec_lv4_dr(lans.l4s));
+    process.write(gen_tp_spec_lv6_dr(lans.l6s));
     process.flush();
     process.close();
 }
@@ -75,11 +110,12 @@ function restart_dnsmasq_if_necessary() {
 const dump = network_dump();
 const dg = get_default_gateway(dump);
 const pd = get_prefix_delegate(dump);
+const lans = get_lan_addresses(dump);
 const log = join(", ", [...dg, ...pd]);
 if (log == "") {
     print("default gateway not available, please wait for interface ready");
 } else {
     print(`default gateway available at ${log}\n`);
-    update_nft(dg, pd);
+    update_nft(dg, pd, lans);
 }
 restart_dnsmasq_if_necessary();

--- a/core/root/usr/share/xray/firewall_include.ut
+++ b/core/root/usr/share/xray/firewall_include.ut
@@ -289,6 +289,17 @@
     }
 {% endif %}
 
+    set tp_spec_lv4_dr {
+        type ipv4_addr
+        size 16
+        flags interval
+    }
+    set tp_spec_lv6_dr {
+        type ipv6_addr
+        size 16
+        flags interval
+    }
+
     chain xray_transparent_proxy {
         type filter hook prerouting priority filter {{ firewall_priority }}; policy accept;
         mark 0x000000fb {{ counter }} goto tp_spec_wan_fw
@@ -424,6 +435,12 @@
         ip6 daddr @tp_spec_dv6_dg {{ counter }} accept
         ip daddr @tp_spec_dv4_bp {{ counter }} accept
         ip6 daddr @tp_spec_dv6_bp {{ counter }} accept
+{% if (general.redirect_dns_port == "1"): %}
+        ip daddr @tp_spec_lv4_dr tcp dport 53 {{ counter }} goto tp_spec_lan_re
+        ip daddr @tp_spec_lv4_dr udp dport 53 {{ counter }} goto tp_spec_lan_re
+        ip6 daddr @tp_spec_lv6_dr tcp dport 53 {{ counter }} goto tp_spec_lan_re
+        ip6 daddr @tp_spec_lv6_dr udp dport 53 {{ counter }} goto tp_spec_lan_re
+{% endif %}
         ip daddr @tp_spec_dv4_sp {{ counter }} accept
         ip6 daddr @tp_spec_dv6_sp {{ counter }} accept
         {{ counter }} goto tp_spec_lan_re

--- a/core/root/usr/share/xray/gen_config.uc
+++ b/core/root/usr/share/xray/gen_config.uc
@@ -114,7 +114,7 @@ function rules(geoip_existence, proxy, bridge, manual_tproxy, extra_inbound, fak
             if (proxy["redirect_dns_port"] == "1") {
                 push(dns_rule, {
                     type: "field",
-                    inboundTag: [...tproxy_tcp_inbound_v6_tags, ...tproxy_udp_inbound_v6_tags, ...built_in_tcp_inbounds, ...tproxy_udp_inbound_v4_tags, ...extra_inbound_global_tcp, ...extra_inbound_global_udp],
+                    inboundTag: [...tproxy_tcp_inbound_v6_tags, ...tproxy_udp_inbound_v6_tags, ...tproxy_tcp_inbound_v4_tags, ...tproxy_udp_inbound_v4_tags, ...extra_inbound_global_tcp, ...extra_inbound_global_udp],
                     network: "tcp,udp",
                     port: 53,
                     outboundTag: "dns_server_outbound"

--- a/core/root/usr/share/xray/gen_config.uc
+++ b/core/root/usr/share/xray/gen_config.uc
@@ -109,6 +109,19 @@ function rules(geoip_existence, proxy, bridge, manual_tproxy, extra_inbound, fak
     const extra_inbound_global_udp = extra_inbound_global_udp_tags() || [];
     let result = [
         ...fake_dns_rules(fakedns),
+        ...function () {
+            const dns_rule = [];
+            if (proxy["redirect_dns_port"] == "1") {
+                push(dns_rule, {
+                    type: "field",
+                    inboundTag: [...tproxy_tcp_inbound_v6_tags, ...tproxy_udp_inbound_v6_tags, ...built_in_tcp_inbounds, ...tproxy_udp_inbound_v4_tags, ...extra_inbound_global_tcp, ...extra_inbound_global_udp],
+                    network: "tcp,udp",
+                    port: 53,
+                    outboundTag: "dns_server_outbound"
+                });
+            }
+            return dns_rule;
+        },
         ...manual_tproxy_rules(manual_tproxy),
         ...extra_inbound_rules(extra_inbound),
         ...system_route_rules(proxy),

--- a/core/root/usr/share/xray/gen_config.uc
+++ b/core/root/usr/share/xray/gen_config.uc
@@ -121,7 +121,7 @@ function rules(geoip_existence, proxy, bridge, manual_tproxy, extra_inbound, fak
                 });
             }
             return dns_rule;
-        },
+        }(),
         ...manual_tproxy_rules(manual_tproxy),
         ...extra_inbound_rules(extra_inbound),
         ...system_route_rules(proxy),

--- a/core/root/www/luci-static/resources/view/xray/core.js
+++ b/core/root/www/luci-static/resources/view/xray/core.js
@@ -674,6 +674,9 @@ return view.extend({
         o.default = "AsIs";
         o.rmempty = false;
 
+        o = s.taboption('dns', form.Flag, 'redirect_dns_port', _('Redirect Subnets DNS Queries'), _('Enable redirecting TCP/UDP port 53 to the xray dns module.'));
+        o.modalonly = true;
+
         s.tab('transparent_proxy_rules', _('Transparent Proxy Rules'));
 
         if (geoip_existence) {


### PR DESCRIPTION
增加一个开关，启用后局域网内客户端 DNS 查询请求一律送往 Xray，无论其 DNS 服务器设置的是什么。

Add a switch. After enabling it, all client DNS query requests in the LAN will be sent to Xray, regardless of its DNS server settings.