### PR TITLE
fix: add ACL for version info

### DIFF
--- a/status/root/usr/share/rpcd/acl.d/luci-app-xray-status.json
+++ b/status/root/usr/share/rpcd/acl.d/luci-app-xray-status.json
@@ -8,6 +8,9 @@
             "file": {
                 "/usr/bin/wget": [
                     "exec"
+                ],
+                "/usr/share/xray/version.txt": [
+                    "read"
                 ]
             }
         }


### PR DESCRIPTION
Hi, 

First of all, thank you very much for your amazing work on this project!

After updating to 3.4.1, I noticed, that the status page stopped working with **PermissionError**.
![Screenshot 2024-03-17 at 01-43-22 gateway - LuCI](https://github.com/yichya/luci-app-xray/assets/16575433/e17907e2-4893-48f1-b3ea-e747dc64b44b)

I tracked it down to [this line](https://github.com/yichya/luci-app-xray/blob/16d2ca8bfe07543b4789f3e829bdc90eb7cfa471/status/root/www/luci-static/resources/view/xray/status.js#L309), where `load()` function tries to read `/usr/share/xray/version.txt` file with `fs.read()` but fails, due to this file missing in ACL for the status package.