### PR TITLE
fix: dnsmasq DNS entries use /#/ wildcard; disable strict-order

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,7 +79,7 @@ jobs:
           fi
           cd -
           file "$CACHE_DIR_SDK/$SDK_FILE"
-          7z x "$CACHE_DIR_SDK/$SDK_FILE" -so | tar -C "$SDK_HOME" -xvf - --strip=1
+          tar --zstd -xf "$CACHE_DIR_SDK/$SDK_FILE" -C "$SDK_HOME" --strip=1
           cd "$SDK_HOME"
           test -d "dl" && rm -rf "dl" || true
           test -d "feeds" && rm -rf "feeds" || true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            sdk_url_path: https://downloads.openwrt.org/releases/23.05.5/targets/x86/64
-            sdk_name: -sdk-23.05.5-x86-64_
+            sdk_url_path: https://downloads.openwrt.org/releases/24.10.5/targets/x86/64
+            sdk_name: -sdk-24.10.5-x86-64_
 
     env:
       SDK_URL_PATH: ${{ matrix.sdk_url_path }}

--- a/core/root/usr/share/xray/dnsmasq_include.ut
+++ b/core/root/usr/share/xray/dnsmasq_include.ut
@@ -9,10 +9,10 @@
     const manual_tproxy = filter(keys(config), k => config[k][".type"] == "manual_tproxy") || [];
 %}
 # Generated dnsmasq configurations by luci-app-xray
-strict-order
+# strict-order
 server=/#/127.0.0.1#{{ dns_port }}
-{% for (let i = dns_port; i <= dns_port + dns_count; i++): %}
-server=127.0.0.1#{{ i }}
+{% for (let i = dns_port+1; i <= dns_port + dns_count; i++): %}
+server=/#/127.0.0.1#{{ i }}
 {% endfor %}
 {% for (let i in manual_tproxy): %}
 {% if (config[i]["rebind_domain_ok"] == "1"): %}


### PR DESCRIPTION
## Summary
- Add `/#/` wildcard to all generated `server=` lines in `dnsmasq_include.ut`. Previously only the first entry had `/#/`, making extra DNS ports (`dns_count`) effectively unused — domain-specific directives take priority over generic ones in dnsmasq.
- Comment out `strict-order` so dnsmasq favours known-up servers instead of strict sequential fallback.
- Fix loop start from `dns_port+1` to avoid duplicating the first entry.

## Problem
With the original template:
```
strict-order
server=/#/127.0.0.1#5300
server=127.0.0.1#5301
server=127.0.0.1#5302
server=127.0.0.1#5303
```
The `/#/` catch-all on port 5300 captures all domains. Ports 5301-5303 as plain `server=` entries are never reached, rendering `dns_count` useless.

## Fix
```
server=/#/127.0.0.1#5300
server=/#/127.0.0.1#5301
server=/#/127.0.0.1#5302
server=/#/127.0.0.1#5303
```
All entries are now equal. Without `strict-order`, dnsmasq picks any known-up server for better failover.

## References
- dnsmasq man page (`-o, --strict-order`): https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
  > "By default, dnsmasq will send queries to any of the upstream servers it knows about and tries to favour servers that are known to be up."