### PR TITLE
fix: dnsmasq DNS entries use /#/ wildcard; disable strict-order

### DIFF
--- a/core/root/usr/share/xray/dnsmasq_include.ut
+++ b/core/root/usr/share/xray/dnsmasq_include.ut
@@ -9,10 +9,10 @@
     const manual_tproxy = filter(keys(config), k => config[k][".type"] == "manual_tproxy") || [];
 %}
 # Generated dnsmasq configurations by luci-app-xray
-strict-order
+# strict-order
 server=/#/127.0.0.1#{{ dns_port }}
-{% for (let i = dns_port; i <= dns_port + dns_count; i++): %}
-server=127.0.0.1#{{ i }}
+{% for (let i = dns_port+1; i <= dns_port + dns_count; i++): %}
+server=/#/127.0.0.1#{{ i }}
 {% endfor %}
 {% for (let i in manual_tproxy): %}
 {% if (config[i]["rebind_domain_ok"] == "1"): %}


### PR DESCRIPTION
## Summary
- Add `/#/` wildcard to all generated `server=` lines in `dnsmasq_include.ut`. Previously only the first entry had `/#/`, making extra DNS ports (`dns_count`) effectively unused — domain-specific directives take priority over generic ones in dnsmasq.
- Comment out `strict-order` so dnsmasq favours known-up servers instead of strict sequential fallback.
- Fix loop start from `dns_port+1` to avoid duplicating the first entry.

## Problem
With the original template:
```
strict-order
server=/#/127.0.0.1#5300
server=127.0.0.1#5301
server=127.0.0.1#5302
server=127.0.0.1#5303
```
The `/#/` catch-all on port 5300 captures all domains. Ports 5301-5303 as plain `server=` entries are never reached, rendering `dns_count` useless.

## Fix
```
server=/#/127.0.0.1#5300
server=/#/127.0.0.1#5301
server=/#/127.0.0.1#5302
server=/#/127.0.0.1#5303
```
All entries are now equal. Without `strict-order`, dnsmasq picks any known-up server for better failover.

## References
- dnsmasq man page (`-o, --strict-order`): https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
  > "By default, dnsmasq will send queries to any of the upstream servers it knows about and tries to favour servers that are known to be up."