### PR TITLE
fix: dnsmasq DNS server entries use /#/ wildcard; disable strict-order; set no-resolv

### DIFF
--- a/core/root/usr/share/xray/dnsmasq_include.ut
+++ b/core/root/usr/share/xray/dnsmasq_include.ut
@@ -9,10 +9,10 @@
     const manual_tproxy = filter(keys(config), k => config[k][".type"] == "manual_tproxy") || [];
 %}
 # Generated dnsmasq configurations by luci-app-xray
-strict-order
+no-resolv
 server=/#/127.0.0.1#{{ dns_port }}
-{% for (let i = dns_port; i <= dns_port + dns_count; i++): %}
-server=127.0.0.1#{{ i }}
+{% for (let i = dns_port + 1; i <= dns_port + dns_count; i++): %}
+server=/#/127.0.0.1#{{ i }}
 {% endfor %}
 {% for (let i in manual_tproxy): %}
 {% if (config[i]["rebind_domain_ok"] == "1"): %}


### PR DESCRIPTION
Previously, only the first `server=` line used the `/#/` catch-all wildcard,
while extra DNS instances generated by `dns_count` used plain `server=`
entries. In dnsmasq, domain-specific directives have higher priority than
generic ones, so the extra ports (5301, 5302, ...) could be starved by the
first catch-all rule and never queried effectively.

Also, keep `strict-order` disabled and explicitly set `no-resolv`:
- Without `strict-order`, dnsmasq can query any known-up upstream and prefer
  healthy servers, improving failover and reducing head-of-line blocking.
- `no-resolv` prevents fallback to resolvers from `/tmp/resolv.conf*` (often
  ISP DNS on OpenWrt WAN). This is critical to avoid polluted DNS answers,
  especially for blocked domains that have no IPv6 records, where leaked ISP
  DNS resolution can bypass intended Xray DNS behavior.

Changes:
- Add `/#/` wildcard to all generated `server=` lines so all configured Xray
  DNS ports are treated uniformly.
- Keep `strict-order` disabled (commented out in template).
- Add `no-resolv` to ensure dnsmasq only uses configured Xray DNS upstreams.
- Start extra-port loop from `dns_port + 1` to avoid duplicate first entry.

References:
- dnsmasq man page (-o/--strict-order, -R/--no-resolv):
  https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
