### PR TITLE
feat: enhance build workflow with multiple SDK versions and improved …

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,15 +12,20 @@ env:
 
 jobs:
   release:
-    name: Build for ${{ matrix.arch }}
+    name: Build for ${{ matrix.arch }} (${{ matrix.id }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
+          - id: 23.05
+            arch: x86_64
             sdk_url_path: https://downloads.openwrt.org/releases/23.05.5/targets/x86/64
             sdk_name: -sdk-23.05.5-x86-64_
+          - id: 25.12
+            arch: x86_64
+            sdk_url_path: https://downloads.openwrt.org/releases/25.12.2/targets/x86/64
+            sdk_name: -sdk-25.12.2-x86-64_
 
     env:
       SDK_URL_PATH: ${{ matrix.sdk_url_path }}
@@ -33,7 +38,7 @@ jobs:
 
       - name: Prepare Cache Key
         id: cache_key
-        run: echo "::set-output name=timestamp::$(date +"%s")"
+        run: echo "timestamp=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Cache
         uses: actions/cache@v4
@@ -41,12 +46,12 @@ jobs:
           path: |
             ${{ env.CACHE_DIR }}
             ${{ env.CCACHE_DIR }}
-          key: openwrt-${{ matrix.arch }}-${{ env.PACKAGE_NAME }}-${{ steps.cache_key.outputs.timestamp }}
+          key: openwrt-${{ matrix.arch }}-${{ matrix.id }}-${{ env.PACKAGE_NAME }}-${{ steps.cache_key.outputs.timestamp }}
           restore-keys: |
-            openwrt-${{ matrix.arch }}-${{ env.PACKAGE_NAME }}-
+            openwrt-${{ matrix.arch }}-${{ matrix.id }}-${{ env.PACKAGE_NAME }}-
       - name: Install Dependencies
         run: |
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ccache gettext libncurses5-dev xsltproc p7zip-full
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ccache gettext libncurses5-dev xsltproc zstd
       - name: Create Directories
         run: |
           CACHE_DIR_SDK="$(eval echo "$CACHE_DIR/sdk")"
@@ -79,7 +84,7 @@ jobs:
           fi
           cd -
           file "$CACHE_DIR_SDK/$SDK_FILE"
-          7z x "$CACHE_DIR_SDK/$SDK_FILE" -so | tar -C "$SDK_HOME" -xvf - --strip=1
+          tar -C "$SDK_HOME" --strip=1 -xf "$CACHE_DIR_SDK/$SDK_FILE"
           cd "$SDK_HOME"
           test -d "dl" && rm -rf "dl" || true
           test -d "feeds" && rm -rf "feeds" || true
@@ -103,16 +108,21 @@ jobs:
           cd "$SDK_HOME"
           make defconfig
           make package/${PACKAGE_NAME}/status/{clean,compile} V=s
-          find "$SDK_HOME/bin/" -type f -name "*.ipk" -exec ls -lh {} \;
+          find "$SDK_HOME/bin/" -type f \( -name "*.ipk" -o -name "*.apk" \) -exec ls -lh {} \;
           cd -
       - name: Copy Bin Files
         run: |
-          find "$SDK_HOME/bin/" -type f -name "${PACKAGE_NAME}*.ipk" -exec cp {} "${{ github.workspace }}" \;
-          find "${{ github.workspace }}" -type f -name "*.ipk" -exec ls -lh {} \;
+          find "$SDK_HOME/bin/" -type f \( -name "${PACKAGE_NAME}*.ipk" -o -name "${PACKAGE_NAME}*.apk" \) | while read -r f; do
+            base="$(basename "$f")"
+            cp "$f" "${{ github.workspace }}/${base%.*}-${{ matrix.arch }}.${base##*.}"
+          done
+          find "${{ github.workspace }}" -maxdepth 1 -type f \( -name "*.ipk" -o -name "*.apk" \) -exec ls -lh {} \;
       - name: Release and Upload Assets
         uses: softprops/action-gh-release@v1
         with:
-          files: "*.ipk"
+          files: |
+            *.ipk
+            *.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Summary
Extends the release workflow to build artifacts for OpenWrt 25.12 in addition to the existing 23.05 target, so each tagged release publishes both .ipk (23.05) and .apk (25.12) packages.

### Changes

- Matrix: split the single x86_64 job into two — 23.05 (SDK 23.05.5, ipk) and 25.12 (SDK 25.12.2, apk). Added an id field per entry so the two jobs are distinguishable in the Actions UI and have separate caches.

- SDK extraction: replaced 7z x … | tar -xvf - with tar -xf directly. Modern tar autodetects compression, which lets the same step handle 23.05's .tar.xz and 25.12's .tar.zst. Swapped the p7zip-full apt dependency for zstd.

- Artifact discovery: build/copy/upload steps now match both *.ipk and *.apk.

- Artifact naming: copied files are suffixed with -${arch} (e.g. luci-app-xray_3.7.1-1_all-x86_64.ipk, luci-app-xray-3.7.1-r1-x86_64.apk) so the two jobs don't overwrite each other on the GitHub Release.

- Misc cleanup: replaced deprecated ::set-output with $GITHUB_OUTPUT.

### Test plan
*  Push a test tag and confirm both jobs (Build for x86_64 (23.05) and Build for x86_64 (25.12)) succeed.
*  Verify the resulting GitHub Release contains four assets: luci-app-xray and luci-app-xray-status in both .ipk and .apk form.
*  Install the .apk on a 25.12 device and the .ipk on a 23.05 device; confirm LuCI app loads and xray-status page works.
