### PR TITLE
Fix config erorr after v26.4.25

### DIFF
--- a/core/root/usr/share/xray/gen_config.uc
+++ b/core/root/usr/share/xray/gen_config.uc
@@ -274,9 +274,6 @@ function gen_config() {
             place: "holder"
         } : null,
         observatory: observatory(general, manual_tproxy),
-        reverse: {
-            bridges: bridges(bridge)
-        },
         routing: {
             domainStrategy: general["routing_domain_strategy"] || "AsIs",
             rules: rules(general, bridge, manual_tproxy, extra_inbound, fakedns),


### PR DESCRIPTION
Commit cd4d0ba
Xray-core: Mark "legacy reverse" as removed to avoid confusions