### PR TITLE
fix: bypass replies to inbound connections

### DIFF
--- a/core/root/usr/share/xray/firewall_include.ut
+++ b/core/root/usr/share/xray/firewall_include.ut
@@ -481,6 +481,7 @@
 
     chain xray_output {
         type route hook output priority mangle {{ firewall_priority }}; policy accept;
+        ct direction reply {{ counter }} accept comment "Xray reply to inbound connection"
 {% if (length(uids_direct) > 0): %}
         meta skuid { {{ join(", ", uids_direct) }} } {{ counter }} accept
 {% endif %}


### PR DESCRIPTION
## What changed

Skip conntrack reply-direction packets in the `xray_output` route chain before router-originated TCP and UDP traffic is evaluated for transparent proxying.

## Why

When OpenWrt also hosts an inbound service, packets generated by that service in response to a WAN-initiated connection traverse the local `output` hook. The current rules send those reply packets through `tp_spec_wan_ac`, so they may be marked and redirected to Xray instead of leaving through WAN.

This was reproduced with a SoftEther/OpenVPN server running on the router: inbound SYN packets reached the service and were accepted by firewall4, but SYN-ACK replies did not leave the PPPoE interface while transparent proxy integration was enabled. Bypassing conntrack reply-direction traffic restored the replies.

`ct direction reply` only matches packets traveling opposite to the first packet recorded for that connection. Router-initiated connections remain in the original direction and continue through the existing Xray output policy.

## Impact

- Preserves transparent proxy handling for router-initiated TCP/UDP connections.
- Allows replies from router-hosted inbound services to use the normal WAN return path.
- Avoids changing packet marks, preserving compatibility with other policy-routing consumers.

## Validation

- `git diff --check`
- Confirmed the equivalent reply-direction bypass restores WAN SYN-ACK traffic on OpenWrt with firewall4 and luci-app-xray transparent proxy enabled.

An OpenWrt SDK was not available locally, and this repository does not include a standalone test runner for the ucode nftables template.
